### PR TITLE
speechTextを初期化

### DIFF
--- a/okite/ViewController.swift
+++ b/okite/ViewController.swift
@@ -115,6 +115,8 @@ class ViewController: UIViewController {
         utterance.voice = AVSpeechSynthesisVoice(language: "ja-JP")
         // 実行
         talker.speak(utterance)
+        
+        speechText = ""
     }
     
     func setAlert(){


### PR DESCRIPTION
1回アラームを設定し、2回目設定しようとするとspeechTextに1回目の値が残りvoice()で読みげられてしまう
。
そのためspeechTextを初期化しました。